### PR TITLE
Fixes warnings and adds sanitizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Compiler
 CC = cc
 CFLAGS = -I$(SRC_DIR)/lib  # Include path for headers
+CFLAGS += -std=gnu23
+CFLAGS += -Wall -Wextra -pedantic
+CFLAGS += -fsanitize=address -fsanitize=undefined
+
 
 # Directories
 SRC_DIR = src

--- a/src/app/about.c
+++ b/src/app/about.c
@@ -17,6 +17,7 @@ static char const html[] =
 "</html>";
 
 int About(ResponseWriter* w, Request* r) {
+    (void)r;
     // Set status and headers
     SetStatus(w, 200, "OK");
     SetHeader(w, "Content-Type", "text/html");

--- a/src/lib/http/req_parser.c
+++ b/src/lib/http/req_parser.c
@@ -1,4 +1,5 @@
 #include "header.h"
+#include <assert.h>
 
 Request* parse_http_request(const char* raw_request) {
     Request* req = (Request*)malloc(sizeof(Request));
@@ -121,8 +122,9 @@ Request* parse_http_request(const char* raw_request) {
             
             case PARSE_BODY: {
                 size_t bytes_remaining = strlen(p);
-                size_t bytes_to_copy = (content_length < bytes_remaining) ? 
-                                     content_length : bytes_remaining;
+                assert(content_length >= 0);
+                size_t bytes_to_copy = ((size_t)content_length < bytes_remaining)
+                    ? (size_t)content_length : bytes_remaining;
                 
                 if (bytes_to_copy > 0 && bytes_to_copy < MAX_BODY_LEN) {
                     memcpy(req->body, p, bytes_to_copy);

--- a/src/lib/http/response_writer.c
+++ b/src/lib/http/response_writer.c
@@ -1,5 +1,7 @@
 #include "header.h"
 
+#include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -28,7 +30,7 @@ void InitResponseWriter(ResponseWriter* rw) {
 
 // Header management functions
 void SetHeader(ResponseWriter* rw, const char* name, const char* value) {
-    for (size_t i = 0; i < rw->header_count; ++i) {
+    for (int i = 0; i < rw->header_count; ++i) {
         if (strcmp(rw->headers[i].name, name) == 0) {
             Header* h = &rw->headers[i];
             strncpy(h->value, value, sizeof(h->value));
@@ -71,8 +73,9 @@ char* BuildResponse(ResponseWriter* rw) {
     
     // Body
     if(rw->body_length > 0) {
-        size_t to_copy = rw->body_length < (response + sizeof(response) - ptr) ? 
-                        rw->body_length : (response + sizeof(response) - ptr);
+        assert(rw->body_length < INT64_MAX);
+        size_t to_copy = (long)rw->body_length < (response + sizeof(response) - ptr)
+            ? (long)rw->body_length : (response + sizeof(response) - ptr);
         memcpy(ptr, rw->body, to_copy);
         ptr += to_copy;
     }

--- a/src/lib/http/server.c
+++ b/src/lib/http/server.c
@@ -1,6 +1,9 @@
 #include "header.h"
 
-HttpServer http = {listenAndServe, handleFunc};
+HttpServer http = {
+  .ListenAndServe = listenAndServe,
+  .HandleFunc = handleFunc,
+};
 
 int listenAndServe(char *host, Router *router) {
   if(router == NULL) {


### PR DESCRIPTION
* Uses c23 standard (gnu version because of `strtok_r`)
* Fixes "unused variable" warnings
* Fixes comparison of sign and unsigned integers. Though, it is only viable for debug builds because of use of `assert`. It is very unlikely those limits will be reached but who knows..
* Fixes partial structure initialization using positional arguments. In case when/if fields will shuffle, initialization code breaks. Designated initialization fixes this problem.