### PR TITLE
fix: remove set gcc-14 as default compiler, and fix static file exten…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ BUILD_TYPE ?= release
 
 # Compiler
 CC ?= cc
-CC := gcc-14
 
 CFLAGS = -I$(SRC_DIR)/lib  # Include path for headers
 CFLAGS += -std=gnu23

--- a/src/app/static.c
+++ b/src/app/static.c
@@ -7,7 +7,7 @@ static inline bool string_ends_with(char const *str, char const *suffix)
 {
     size_t str_len = strlen(str);
     size_t suffix_len = strlen(suffix);
-    return suffix_len <= str_len && memcmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
+    return suffix_len < str_len && memcmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
 }
 
 static char const *get_mime_type(char const *filename)

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -14,7 +14,6 @@ die() {
 SERVER_PID=$!
 
 PORT=${PORT:-9000}
-export PORT
 HOST="http://localhost:$PORT"
 
 # Wait at most 5 seconds for the server to start


### PR DESCRIPTION
## description

Remove the setting of gcc-14 as default compiler, and fix static file extension checking

## changes

- Fix static file extension check to use < instead of <= to prevent matching hidden files
- Remove gcc-14 as default compiler.
- Remove the PORT export in integration tests script.

## unchanged

The PORT variable is used to identify the port the server will be bound to. The integration test script needs to let hurl know which port to use to make requests.