### PR TITLE
Integrates `zc` for template processing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,6 @@ jobs:
 
     - name: Build C code
       run: |
-        make bin/thc
         make compile_templates
         make bin/server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ RUN pip3 install --break-system-packages pre-commit
 RUN apt-get update && apt-get install -y pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
+# Build and install `zc` tool
+RUN git clone --depth=1 https://github.com/koutoftimer/zc.git /tmp/zc
+RUN make --directory=/tmp/zc --jobs=$(nproc)
+RUN make --directory=/tmp/zc install
+
 # Set workspace for GitHub Actions
 WORKDIR /github/workspace
 

--- a/Makefile
+++ b/Makefile
@@ -86,23 +86,16 @@ test: $(BIN_DIR)/gtest
 	$(BIN_DIR)/gtest
 
 #
-# Tools
-#
-
-# Build Template Header Compiler
-$(BIN_DIR)/thc: $(SRC_DIR)/tools/thc.c $(LIBRARY_OBJECTS)
-	@mkdir -p $(dir $@)
-	$(CC) $(INCLUDES) $(CFLAGS) -o $@ $^
-
-#
 # Compile template files
 #
+
+ZC_TOOL_PATH ?= zc
 
 TEMPLATES_DIR = $(SRC_DIR)/app/templates
 TEMPLATES = $(shell find $(TEMPLATES_DIR) -name '*.html')
 
 $(TEMPLATES_DIR)/%.h: $(TEMPLATES_DIR)/%.html
-	$(BIN_DIR)/thc $^ > $@
+	$(ZC_TOOL_PATH) $^ > $@
 
 define template_to_header
 $(patsubst $(TEMPLATES_DIR)/%.html,$(TEMPLATES_DIR)/%.h,$(1))


### PR DESCRIPTION
I've updated an image on docker.io to include `zc`, now there is one less build step but you'll have to build it locally for local development.

You can either build and install it somewhere

```
pushd $(mktemp -d)
git clone --depth=1 https://github.com/koutoftimer/zc.git .
make PREFIX="$HOME/opt"
make PREFIX="$HOME/opt" install
popd
echo "export ZC_TOOL_PATH='$HOME/opt/zc/bin/zc'" > .env
source .env
```

or  you can install it into `$HOME/.local/` it if is in your `echo $PATH` then it will be visible everywhere for your user

or use podman (as it creates files with user permissions, unlike docker which creates them from root)

```
export ZC_TOOL_PATH="podman run --rm -v '$PWD':/github/workspace koutoftimer/oduortoni-c-http-server-actions:latest zc"
make compile_templates
make bin/server
```

Let me know if you have an idea how to make smoother experience.