### PR TITLE
fix: format failure

### DIFF
--- a/src/lib/http/http_response_writer.c
+++ b/src/lib/http/http_response_writer.c
@@ -93,7 +93,7 @@ char*
 BuildResponse(ResponseWriter* rw)
 {
         char* response =
-            malloc(4096);  // we can avoid using the constant 4096 later
+            malloc(4096);  // TODO: we can avoid using the constant 4096 later
         if (!response) return nullptr;
 
         constexpr size_t response_size = 4096 - 1;


### PR DESCRIPTION
There was a temporary failure in my formatter. This pr fixes the extra whitespaces.

# no need to review